### PR TITLE
(Pin): Pin Button onclick Toggles CSS Class

### DIFF
--- a/app/javascript/controllers/pin_comment_controller.js
+++ b/app/javascript/controllers/pin_comment_controller.js
@@ -1,0 +1,10 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="pin-comment"
+export default class extends Controller {
+  static targets = [ 'comment' ]
+
+  toggleClass() {
+    this.commentTarget.classList.toggle('pinned-comment')
+  }
+}

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_stream_from comment %>
 <%= turbo_frame_tag comment do %>
-  <div class="card comment <%= 'pinned-comment' if comment.pin %>"><!-- TODO: realtime class update, broadcast pin update_to self -->
+  <div class="card comment <%= 'pinned-comment' if comment.pin %>" data-pin-comment-target="comment">
     <div class="card-body d-flex flex-column w-100">
       <h6 class="card-subtitle mb-2 text-muted">
         <span id="<%= dom_id(comment) %>_user_username"><%= t('by_username', username: comment.user.username) %></span>

--- a/app/views/comments/_comment_with_replies.html.erb
+++ b/app/views/comments/_comment_with_replies.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_stream_from comment, :comments %>
 
-<div class="<%= 'ps-3 border-left' unless comment.parent.nil? || defined?(is_root_comment) %> mt-3" id="<%= dom_id(comment) %>_with_comments" data-controller="comment-reply turbo-frame-visibility">
+<div class="<%= 'ps-3 border-left' unless comment.parent.nil? || defined?(is_root_comment) %> mt-3" id="<%= dom_id(comment) %>_with_comments" data-controller="comment-reply turbo-frame-visibility pin-comment">
   <%= render partial: 'comments/comment', locals: { comment: comment } %>
 
   <div class="text-sm mt-1 mb-3 d-flex">

--- a/app/views/pins/button/_pin.html.erb
+++ b/app/views/pins/button/_pin.html.erb
@@ -1,3 +1,3 @@
 <%= tag.div id: "#{dom_id(comment)}_pin" do %>
-  <%= button_to 'Pin', pins_path(pin: { story_id: comment.commentable.id, comment_id: comment.id }), class: "btn btn-link" %>
+  <%= button_to 'Pin', pins_path(pin: { story_id: comment.commentable.id, comment_id: comment.id }), data: { action: 'click->pin-comment#toggleClass' }, class: "btn btn-link" %>
 <% end %>

--- a/app/views/pins/button/_unpin.html.erb
+++ b/app/views/pins/button/_unpin.html.erb
@@ -1,3 +1,3 @@
 <%= tag.div id: "#{dom_id(comment)}_pin" do %>
-  <%= button_to 'Unpin', pin_path(comment.pin), method: :delete, class: "btn btn-link" %>
+  <%= button_to 'Unpin', pin_path(comment.pin), data: { action: 'click->pin-comment#toggleClass' }, class: "btn btn-link", method: :delete %>
 <% end %>


### PR DESCRIPTION
## Related Issue

Fixes #66 

## Description

This PR adds a new stimulus controller that toggles the `pinned-comment` class when the pin button underneath the comment is clicked.
