### PR TITLE
(Comment): Clean Up turbo_streams

### DIFF
--- a/app/views/stories/comments/_comment.html.erb
+++ b/app/views/stories/comments/_comment.html.erb
@@ -1,4 +1,3 @@
-<%= turbo_stream_from dom_id(comment) %>
 <%= tag.div id: dom_id(comment) do %>
   <div class="card comment <%= 'pinned-comment' if comment.pin %>" data-pin-comment-target="comment">
     <div class="card-body d-flex flex-column w-100">

--- a/app/views/stories/comments/_comment_with_replies.html.erb
+++ b/app/views/stories/comments/_comment_with_replies.html.erb
@@ -1,5 +1,3 @@
-<%= turbo_stream_from "#{dom_id(comment)}_comments" %>
-
 <div class="<%= comment.parent.nil? || defined?(is_root_comment) ? 'mt-3' : 'ps-3 border-left' %> py-1" id="<%= dom_id(comment) %>_with_comments" data-controller="comment-reply pin-comment">
 
   <%= render partial: 'stories/comments/comment', locals: { comment: comment } %>

--- a/app/views/stories/comments/show.turbo_stream.erb
+++ b/app/views/stories/comments/show.turbo_stream.erb
@@ -1,5 +1,4 @@
 <%= turbo_stream.replace "#{dom_id(@story)}_comments" do %>
-  <%= turbo_stream_from "#{dom_id(@story)}_comments" %>
   <div id="<%= dom_id(@story) %>_comments" data-controller="scroll-into-view">
     <% if @comment.parent&.level.to_i <= 9 %>
       <%= link_to("Back to previous comments", story_path(@story.id)) %>


### PR DESCRIPTION
## Related Issue

Fixes #98 

## Description

This PR removes some unnecessary `turbo_stream_from`s from the comment view templates
