### PR TITLE
(System): Get Rid of @rails/ujs

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,10 +4,6 @@ import * as bootstrap from "bootstrap"
 import "controllers"
 import "@hotwired/turbo-rails"
 
-// TODO: remove these 2 lines(@rails/ujs) and replace link_to delete with buttons
-import Rails from '@rails/ujs'
-Rails.start()
-
 import "trix"
 import "@rails/actiontext"
 

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -13,7 +13,7 @@
             <li><%= link_to t('profile'), user_path(username: current_user.username), id: 'navbar-userpage', class: 'dropdown-item' if user_signed_in? %></li>
             <li><%= link_to t('users.sign_up'), new_user_registration_path, id: 'navbar-sign-up', class: 'dropdown-item' unless user_signed_in? %></li>
             <li><%= link_to t('users.log_in'), new_user_session_path, id: 'navbar-log-in', class: 'dropdown-item' unless user_signed_in? %></li>
-            <li><%= link_to t('users.log_out'), destroy_user_session_path, method: :delete, id: 'navbar-log-out', class: 'dropdown-item' if user_signed_in? %></li>
+            <li><%= button_to t('users.log_out'), destroy_user_session_path, method: :delete, id: 'navbar-log-out', class: 'dropdown-item btn-link' if user_signed_in? %></li>
           </ul>
         </div>
       </div>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -10,6 +10,5 @@ pin_all_from 'app/javascript/controllers', under: 'controllers'
 pin '@hotwired/turbo-rails', to: 'turbo.min.js', preload: true
 pin 'bootstrap', to: 'https://ga.jspm.io/npm:bootstrap@5.1.3/dist/js/bootstrap.esm.js'
 pin '@popperjs/core', to: 'https://unpkg.com/@popperjs/core@2.11.2/dist/esm/index.js' # use unpkg.com as ga.jspm.io contains a broken popper package
-pin '@rails/ujs', to: 'https://ga.jspm.io/npm:@rails/ujs@7.0.4/lib/assets/compiled/rails-ujs.js' # TODO: remove @rails/ujs and replace link_to delete with buttons
 pin 'trix'
 pin '@rails/actiontext', to: 'actiontext.js'

--- a/test/system/navbar_test.rb
+++ b/test/system/navbar_test.rb
@@ -53,7 +53,7 @@ class NavbarTest < ApplicationSystemTestCase
     assert_equal new_user_session_url, current_url
   end
 
-  # TODO: fix this - remove @rails/ujs and replace link_to delete with buttons
+  # TODO: fix this
   # test 'log_out link works' do
   #   sign_in create(:user)
   #   visit root_url


### PR DESCRIPTION
## Related Issue

Fixes #24 

## Description

Since `@rails/ujs` is deprecated, this PR removes it from the system
